### PR TITLE
Update jmxbridge_rn_1_7.html.md.erb

### DIFF
--- a/p1-v1.7/jmxbridge_rn_1_7.html.md.erb
+++ b/p1-v1.7/jmxbridge_rn_1_7.html.md.erb
@@ -3,15 +3,18 @@ title: Pivotal Cloud Foundry&reg; JMX Bridge v1.7.X Release Notes
 owner: Metrix
 ---
 
-## Version 1.7.0
+## Version 1.7.2
 
 ### Known issues
 For Known Issues, please see [Ops Metrics Known Issues](../p1-v1.6/opsmetrics_ki_1_6.html).
 
 ### Notes
+**Version 1.7.2**
+* Fixes issue where you could not upgrade from Ops Metrics 1.6.10+ if you had already upgraded to OpsMan 1.7
+* Stemcell remains the same at 3232
+**Version 1.7.1**
+* Removes the bosh job ID from metric name
+* Updated stemcell for 1.7.1 to 3232
+**Version 1.7.0**
 * Product name has been changed from "Ops Metrics" to "JMX Bridge"
 * Stemcell for 1.7.0 is 3149
-
-### Deprecation
-* JMX Bridge functionality will be rolled into PCF Metrics tile as of 1.8
-* Collector will be eliminated from the JMX Bridge tree as of 1.8


### PR DESCRIPTION
Correcting several issues with this page
* removed the Deprecation section as it's definitely inaccurate at this point; we will re-add this section when there is a known deprecation path forward
* the latest version is v1.7.2
* Made it clearer in notes that name change originated from Ops Metrics to this name with 1.7.0 
* Back-versioned some release notes for prior patch versions of 1.7.x