### PR TITLE
Removing references to deprecated 1.5 version

### DIFF
--- a/p1-v1.6/opsmetrics_ki_1_6.md
+++ b/p1-v1.6/opsmetrics_ki_1_6.md
@@ -17,17 +17,3 @@ For all 1.6.X releases:
 For the 1.6.0 release:
 * Leaving the port blank in Elastic Runtime would cause the OpenTSDB firehose nozzle to try to listen to port 0.   To fix, enter port 443 in Elastic Runtime or use Ops Metrics 1.6.1 .
 
-## New Issues for 1.5.X
-
-Note: The 1.5.X line has been completely deprecated in favor of 1.6.X.  Please use 1.6.X if at all possible.
-
-Some of these issues may be fixed in subsequent patch releases to 1.5. Consult the Ops Metrics 1.5 [Release Notes](opsmetrics_rn_1_6.html) - any additional fixes will be added immediately.
-
-* On a new [Pivotal Cloud Foundry&reg;](https://network.pivotal.io/products/pivotal-cf) (PCF) Ops Manager install, you must install an Elastic Runtime tile before installing Ops Metrics 1.5.X . Ops Metrics 1.5.X may fail with a "500 error" if the Elastic Runtime tile is not present. Ops Manager will continue to produce errors for subsequent deployments of Ops Metrics, even if you add the Elastic Runtime tile after.
-* To resolve this issue:
-  * Uninstall the Ops Metrics tile 1.5.X tile.
-  * Install the Elastic Runtime 1.6.X tile, if you have not done so already.  (There is no need to remove an already present Elastic Runtime tile for this fix to work.)
-  * Verify your Elastic Runtime 1.6.X tile is running.
-  * Finally re-install Ops Metrics 1.5.X .
-
-* If you would like to deploy Ops Metrics solely for Bosh data, please install a 1.4 version of Ops Metrics. Do not upgrade to Ops Metrics 1.5 unless you have an Elastic Runtime tile installed.


### PR DESCRIPTION
These notes are very old, and while we still support patch versions of Ops Metrics 1.4 & Ops Metrics 1.6, version 1.5 was deprecated due to instability and has not been an available release for a long time. Removing references to it as it is already 2+ versions behind current and could be confusing to be on this page when it is not a valid release option for PCF users.