### PR TITLE
Removing RN references to deprecated 1.5 version

### DIFF
--- a/p1-v1.6/opsmetrics_rn_1_6.md
+++ b/p1-v1.6/opsmetrics_rn_1_6.md
@@ -6,7 +6,7 @@ owner: PCF Metrics
 ## v1.6.10 patch release:
 Ops Metrics 1.6.10 includes a fix for Ubuntu Security Notice USN-2929-1. (Embedded stemcell 3146.10, Ops Metrics build bdb56a2)
 
-## Version 1.6.X (changes since v1.5.x)
+## Version 1.6.13 
 
 ### Known issues
 For Known Issues, please see the [Ops Metrics Known Issues](./opsmetrics_ki_1_6.html) documentation.  For Ops Metrics 1.6.X there is one important install ordering dependency before enabling the OpenTSDB firehose nozzle job.
@@ -26,21 +26,4 @@ For Known Issues, please see the [Ops Metrics Known Issues](./opsmetrics_ki_1_6.
 * Upgrading from Ops Metrics 1.4.X to 1.6.X will leave the firehose nozzle job disabled (since it did not exist previously).
 * Upgrading from Ops Metrics 1.5.X to 1.6.X will enable the firehose nozzle by default (since it was enabled before upgrading).
   * If you are upgrading to resolve an installation error with 1.5.X, immediately disable the firehose job before deploying, and enable once you have deployed Elastic Runtime.
-* Stemcell for 1.6.0 is 3144
-
-## Version 1.5.X (changes since v1.4.x)
-
-### Known issues
-For Known Issues, please see the [Ops Metrics Known Issues](./opsmetrics_ki_1_6.html) documentation.  For Ops Metrics 1.5.X (compatible with Ops Manager and Elastic Runtime 1.6.X ) there is one important install ordering dependency.
-
-### Major Features
-* Ops Metrics now supports the firehose in addition to Bosh and the Collector for data.
-* This requires the Elastic Runtime tile to be deployed before Ops Metrics (see known issues)
-
-### Bug Fixes
-* In the event of a data collision, Ops Metrics now keeps the last value that arrived by timestamp.
-
-### Notes
-* Stemcell for 1.5.2 is 3130
-* Stemcell for 1.5.1 is 3112
-* Stemcell for 1.5.0 is 3100
+* Stemcell for 1.6.13 is 3232.6


### PR DESCRIPTION
These notes are very old, and while we still support patch versions of Ops Metrics 1.4 & Ops Metrics 1.6, version 1.5 was deprecated due to instability and has not been an available release for a long time. Removing references to it as it is already 2+ versions behind current and could be confusing to be on this page when it is not a valid release option for PCF users. I did leave one note in upgrade path just in case someone still has a bad 1.5 out there and wants to move to 1.6. I also updated the version number and required stemcell to latest available on PivNet. I expect to make another PR soon when we release another 1.6 patch in support of an existing CVE