### PR TITLE
Added bump release to docs that reference 1.0

### DIFF
--- a/p1-v1.6/pcfmetrics_rn_1_6.html.md.erb
+++ b/p1-v1.6/pcfmetrics_rn_1_6.html.md.erb
@@ -2,6 +2,22 @@
 title: Pivotal Cloud Foundry Metrics Release Notes
 owner: Metrix
 ---
+## Version 1.0.11
+
+### Known issues
+For Known Issues, please see [PCF Metrics Known Issues](../p1-v1.6/pcfmetrics_ki_1_6.html).
+
+### Notes
+* Update to use Stemcell 3232.17
+
+## Version 1.0.10
+
+### Known issues
+For Known Issues, please see [PCF Metrics Known Issues](../p1-v1.6/pcfmetrics_ki_1_6.html).
+
+### Notes
+* BUG FIX: Corrects issue in 1.0.9 where the UI errand was not properly bumped to CLI v6.19, causing UI push to fail in some environments.
+
 ## Version 1.0.9
 
 ### Known issues


### PR DESCRIPTION
Bumped product to 1.0.11; updating RN; also updated since adding 1.0.10 was apparently missed here