### PR TITLE
Update pcfmetrics_rn_1_6.html.md.erb

### DIFF
--- a/p1-v1.6/pcfmetrics_rn_1_6.html.md.erb
+++ b/p1-v1.6/pcfmetrics_rn_1_6.html.md.erb
@@ -2,6 +2,22 @@
 title: Pivotal Cloud Foundry Metrics Release Notes
 owner: Metrix
 ---
+## Version 1.0.14
+
+### Known issues
+For Known Issues, please see [PCF Metrics Known Issues](../p1-v1.6/pcfmetrics_ki_1_6.html).
+
+### Notes
+* Update to use Stemcell 3232.21
+
+## Version 1.0.13
+
+### Known issues
+For Known Issues, please see [PCF Metrics Known Issues](../p1-v1.6/pcfmetrics_ki_1_6.html).
+
+### Notes
+* Release bumps required CLI to CLI v6.21.1 and configures CLI environment variable CF\_DIAL\_TIMEOUT to 30 seconds to reduce chance of CLI errors when network connection attempts include slow DNS resolution times
+
 ## Version 1.0.11
 
 ### Known issues


### PR DESCRIPTION
Noticed these PCF 1.6 specific set of docs was now 2 versions behind with today's Metrics 1.0.14 bump. Added updates for recently released 1.0.13 and new 1.0.14