### PR TITLE
Correction to KI based on loggregator patch work

### DIFF
--- a/runtime-rn.html.md.erb
+++ b/runtime-rn.html.md.erb
@@ -243,10 +243,9 @@ Please ask your Cloud Foundry Operator to check the platform configuration
 
 **Solution**: Upgrade to cf CLI version 6.23 or later. After you upgrade, if you still encounter the connection issue, make sure you log out and log in again using `cf logout` and `cf login`.
 
-### <a id="invalid-metric"></a> Messages Received Firehose Metric Invalid in JMX Bridge
+### <a id="invalid-metric"></a> Recommended Messages Received Firehose Metric Not Accurate in ERT 1.10.0
 
-In PCF v1.10, the recommended metric for monitoring firehose message throughput is changing to `DopplerServer.listeners.receivedEnvelopes`. However, this metric utilizes a new tagged metric structure that the JMX Bridge does not handle. If you consume metrics with JMX Bridge, you should use `DopplerServer.listeners.totalReceivedMessageCount` for monitoring firehose message throughput.   
-
-* As of ERT 1.10.0 `DopplerServer.listeners.totalReceivedMessageCount` is not an accurate metric for all possible firehose traffic. This is being patched. JMX Bridge will require this patch version.
-* As of ERT 1.10.1, users of JMX Bridge can reliably monitor throughput using `DopplerServer.listeners.totalReceivedMessageCount`.
+In PCF v1.10, the recommended metric for monitoring firehose message throughput is changing to `DopplerServer.listeners.totalReceivedMessageCount`. 
+* As of ERT 1.10.0 `DopplerServer.listeners.totalReceivedMessageCount` is not an accurate metric for all possible firehose traffic. This is being patched. 
+* As of ERT 1.10.1, `DopplerServer.listeners.totalReceivedMessageCount` can be expected to accurately represent a count of firehose message throughput.  
 

--- a/runtime-rn.html.md.erb
+++ b/runtime-rn.html.md.erb
@@ -245,8 +245,8 @@ Please ask your Cloud Foundry Operator to check the platform configuration
 
 ### <a id="invalid-metric"></a> Messages Received Firehose Metric Invalid in JMX Bridge
 
-In PCF v1.10, the recommended metric for monitoring firehose message throughput is changing from `DopplerServer.listeners.receivedMessageCount` to `DopplerServer.listeners.receivedEnvelopes`. However, the latter metric utilizes a new tagged metric structure that the JMX Bridge does not handle. If you consume metrics with JMX Bridge, you should continue to use `DopplerServer.listeners.receivedMessageCount` for monitoring firehose message throughput.   
+In PCF v1.10, the recommended metric for monitoring firehose message throughput is changing to `DopplerServer.listeners.receivedEnvelopes`. However, this metric utilizes a new tagged metric structure that the JMX Bridge does not handle. If you consume metrics with JMX Bridge, you should use `DopplerServer.listeners.totalReceivedMessageCount` for monitoring firehose message throughput.   
 
-* As of ERT 1.10.0 `DopplerServer.listeners.receivedMessageCount` is not an accurate metric for all possible firehose traffic. This is being patched. JMX Bridge will require this patch version.
-* As of ERT 1.10.1, users of JMX Bridge can reliably monitor throughput using `DopplerServer.listeners.receivedMessageCount`.
+* As of ERT 1.10.0 `DopplerServer.listeners.totalReceivedMessageCount` is not an accurate metric for all possible firehose traffic. This is being patched. JMX Bridge will require this patch version.
+* As of ERT 1.10.1, users of JMX Bridge can reliably monitor throughput using `DopplerServer.listeners.totalReceivedMessageCount`.
 


### PR DESCRIPTION
Updating submitted RN jmx note. Loggregator team communicated that the metric being backpatched needed a slight name tweak. Additionally it wasn't as clean as "from this to that" as originally communicated so altering the reference that sounded like this former metric was a name-correct metric pre 1.10; it was not. Based on the work loggregator is implementing today to get into an ERT 1.10 patch, this corrected note should now be accurate.