### PR TITLE
Fix stemcell version for ERT 1.12.13.

### DIFF
--- a/runtime-rn.html.md.erb
+++ b/runtime-rn.html.md.erb
@@ -39,7 +39,7 @@ providers](https://www.cloudfoundry.org/provider-requirements/).
   </thead>
   <tbody>
   <tr>
-    <td>Stemcell</td><td>3464.21</td>
+    <td>Stemcell</td><td>3468.21</td>
   </tr><tr>
     <td>binary-offline-buildpack</td><td>1.0.15</td>
   </tr><tr>


### PR DESCRIPTION
I believe there's a typo in the release notes for ERT 1.12.13. The prose refers to 3468.21, which exists, but the version table mentions 3464.21, which doesn't.