### PR TITLE
Add details of NFS Volume Services backward incompatible changes when migrating to PCF 1.12

### DIFF
--- a/breaking-changes.html.md.erb
+++ b/breaking-changes.html.md.erb
@@ -50,6 +50,15 @@ If your existing PCF v1.11.x installation includes both [PCF Runtime for Windows
 
 If you do not upgrade MySQL for PCF, the upgrade fails. For more information, see [Upgrade MySQL for PCF](https://docs.pivotal.io/pivotalcf/1-12/customizing/upgrading-pcf.html#upgrade-mysql).
 
+### <a id="readonly-volume-mounts"></a> Read-only Volume Mounts
+
+We back-ported a fix from NFS 1.3.1 to NFS 1.2.1 for an incompatibility between our NFS Volume release and Diego's container runtime, garden. But, because the fix was in the NFS Service Broker, and service bindings created by old versions of this broker won't get migrated during upgrade, existing NFS service bindings that specify read-only mounts will still exhibit the incompatibility.
+
+As a result, customers upgrading from versions containing nfs-volume-release < 1.2.1 that have NFS services bound read-only to their applications will see that their applications crash after upgrade.
+
+To fix this condition, customers should unbind the service, rebind it, and then restage the application.
+
+Alternately, customers wishing to avoid application down time can temporarily re-bind their applications as read/write before upgrading, and then swtich to read-only afterwards.
 
 ## <a id='ops-man'></a> Ops Manager
 


### PR DESCRIPTION
[#159290036](https://www.pivotaltracker.com/story/show/159290036)