### PR TITLE
The URL link is wrong

### DIFF
--- a/breaking-changes.html.md.erb
+++ b/breaking-changes.html.md.erb
@@ -28,7 +28,7 @@ In PAS v2.3, traffic between the Gorouter and Cloud Controller is encrypted. To 
 
 ### <a id="backup-restore-name-change"></a> backup-prepare Instance Group Has Been Renamed to backup_restore
 
-The name of the `backup-prepare` instance group has been changed to `backup_restore`. This may break some external tools that were setting the properties for this instance group through the Ops Manager API. See the article [PAS backup-prepare job renamed to backup-restore may cause automation failures](https://pivotal.lightning.force.com/lightning/r/KnowledgeArticle__kav/ka00e0000009loEAAQ/view) in the Pivotal Knowledge Base for details.
+The name of the `backup-prepare` instance group has been changed to `backup_restore`. This may break some external tools that were setting the properties for this instance group through the Ops Manager API. See the article [PAS backup-prepare job renamed to backup-restore may cause automation failures](https://community.pivotal.io/s/article/PAS-backup-prepare-job-renamed-to-backup-restore-may-cause-automation-failures) in the Pivotal Knowledge Base for details.
 
 
 ### <a id='grootfs'></a> Newly-Enabled GrootFS May Require Higher Disk Quotas for Docker Apps


### PR DESCRIPTION
The URL link for changes "Backup-prepare Instance Group Has Been Renamed to backup_restore" is wrong as below.
https://pivotal.lightning.force.com/lightning/r/KnowledgeArticle__kav/ka00e0000009loEAAQ/view

This URL is for internal CRM system based on SalesForce which is only applicable to Pivotal customer service team internally.

The correct URL should be as below and I modified it.
https://community.pivotal.io/s/article/PAS-backup-prepare-job-renamed-to-backup-restore-may-cause-automation-failures