### PR TITLE
URL link for C2C Networking is wrong

### DIFF
--- a/runtime-rn.html.md.erb
+++ b/runtime-rn.html.md.erb
@@ -243,7 +243,7 @@ For more information about GrootFS in PCF, see the following topics:
 
 Operators and Developers can click **Networking** in Apps Manager to set container-to-container networking polices. To set container-to-container networking polices you must have the `network.admin` or `network.write` UAA scope.
 
-For more information, see [Create Container-to-Container Networking Policies](http://docs-pcf-staging.cfapps.io//pivotalcf/2-3/console/manage-apps.html#networking).
+For more information, see [Create Container-to-Container Networking Policies](https://docs.pivotal.io/pivotalcf/2-3/console/manage-apps.html#networking).
 
 ### <a id="autoscaling-rules"></a> Create Custom and Compare Rules for Autoscaling in Apps Manager
 


### PR DESCRIPTION
The URL link for Container-to-Container Networking is directed to staging site by mistake, as below.
http://docs-pcf-staging.cfapps.io//pivotalcf/2-3/console/manage-apps.html#networking

It should be as below and I modified it.
https://docs.pivotal.io/pivotalcf/2-3/console/manage-apps.html#networking