### PR TITLE
URL link is wrong.

### DIFF
--- a/runtime-rn.html.md.erb
+++ b/runtime-rn.html.md.erb
@@ -340,7 +340,7 @@ restore** checkbox.
 Before you can enable backup and restore for external Azure blobstores,
 you must enable Soft Delete.
 
-For more information, see the [External Azure Storage](https://docs-pcf-staging.cfapps.io/pivotalcf/2-3/customizing/azure-er-config.html#external_azure) section of <em>Deploying PAS on Azure</em>.
+For more information, see the [External Azure Storage](https://docs.pivotal.io/pivotalcf/2-3/customizing/azure-er-config.html#external_azure) section of <em>Deploying PAS on Azure</em>.
 
 ### <a id='restore-blobstore'></a> Azure Blobstore Can Be Restored to a Separate Storage Account
 


### PR DESCRIPTION
According to the following docs,
https://docs.pivotal.io/pivotalcf/2-3/pcf-release-notes/runtime-rn.html#enable-azure-bbr

it says to refer to the following docs for details regarding External Azure Storage.
https://docs-pcf-staging.cfapps.io/pivotalcf/2-3/customizing/azure-er-config.html#external_azure

But the URL is for internal staging site. The correct URL should be below and I modified it.
https://docs.pivotal.io/pivotalcf/2-3/customizing/azure-er-config.html#external_azure