### PR TITLE
The URL link is broken

### DIFF
--- a/segment-rn.html.md.erb
+++ b/segment-rn.html.md.erb
@@ -152,7 +152,7 @@ In IST v2.3, IST component VMs no longer include the `consul_agent` job. IST com
 
 However, the `consul_server` VM continues to exist in PAS deployments to support any service or partner tiles that still require communication with Consul.
 
-<p class='note breaking'><strong>Breaking Change:</strong> Enabling mTLS creates certain limitations. For more information, see <a href="#mutual-tls-id-limitations">Limitations with Mutual TLS App Identity Verification</a> in the <em>Known Issues</em> section.</p>
+<p class='note breaking'><strong>Breaking Change:</strong> Enabling mTLS creates certain limitations. For more information, see <a href="https://docs.pivotal.io/pivotalcf/2-3/pcf-release-notes/runtime-rn.html#mutual-tls-id-limitations">Limitations with Mutual TLS App Identity Verification</a> in the <em>Known Issues</em> section.</p>
 
 ## <a id='adv-features'></a> About Advanced Features
 


### PR DESCRIPTION
The URL link for "Limitations with Mutual TLS App Identity Verification" is broken. The link makes it jump to the local page which id is "mutual-tls-id-limitations" but it does not exist in this local page.

Instead, the link makes it jump to release note page for PAS v2.3 as below.
https://docs.pivotal.io/pivotalcf/2-3/pcf-release-notes/runtime-rn.html#mutual-tls-id-limitations