### PR TITLE
Add notes about the importance of scaling syslog

### DIFF
--- a/runtime-rn.html.md.erb
+++ b/runtime-rn.html.md.erb
@@ -1491,4 +1491,5 @@ If you want to configure a list of ports, Pivotal recommends following these ste
 
 ### <a id="loggregator-scaling"></a> Loggregator Component Horizontal Scaling Thresholds
 
-Above approximately 40 Doppler instances and 20 Traffic Controller instances, horizontal scaling is no longer useful for improving Loggregator Firehose performance. To improve performance, increase CPU resources for the existing Doppler and Traffic Controller instances to add vertical scale.
+Above approximately 40 Doppler instances and 25 Traffic Controller instances, horizontal scaling is no longer useful for improving Loggregator Firehose performance. To improve performance, increase CPU resources for the existing Doppler and Traffic Controller instances to add vertical scale.
+The Syslog Adapter now enforces a hard limit on how many application syslog drains it can service, therefore it is important to follow the [scaling recommendations](https://docs.pivotal.io/pivotalcf/2-2/monitoring/key-cap-scaling.html#scalable-syslog) to ensure that all syslog drains can be serviced.

--- a/runtime-rn.html.md.erb
+++ b/runtime-rn.html.md.erb
@@ -1492,4 +1492,5 @@ If you want to configure a list of ports, Pivotal recommends following these ste
 ### <a id="loggregator-scaling"></a> Loggregator Component Horizontal Scaling Thresholds
 
 Above approximately 40 Doppler instances and 25 Traffic Controller instances, horizontal scaling is no longer useful for improving Loggregator Firehose performance. To improve performance, increase CPU resources for the existing Doppler and Traffic Controller instances to add vertical scale.
+
 The Syslog Adapter now enforces a hard limit on how many application syslog drains it can service, therefore it is important to follow the [scaling recommendations](https://docs.pivotal.io/pivotalcf/2-2/monitoring/key-cap-scaling.html#scalable-syslog) to ensure that all syslog drains can be serviced.


### PR DESCRIPTION
The syslog adapter now have a hard limit that each vm can only process 500 syslog dranis. Therefore we should point this out in the release notes.