### PR TITLE
Elaborate on implications of Apps Manager security fix

### DIFF
--- a/runtime-rn.html.md.erb
+++ b/runtime-rn.html.md.erb
@@ -13,7 +13,7 @@ Read more about the [certified provider program](https://www.cloudfoundry.org/pr
 
 ### <a id='2.4.3'></a> 2.4.3
 
-* **[Security Fix]** Apps Manager verifies SSL certificates for endpoints to which it proxies
+* **[Security Fix]** Apps Manager verifies SSL certificates for endpoints to which it proxies. For environments using self-signed certificates or certificates that are signed by a certificate authority that is not trusted by the BOSH Director, this may cause Apps Manager to show no content. See [the steps for adding a trusted certificate authority to the BOSH Director](https://docs.pivotal.io/pivotalcf/2-4/om/aws/config-manual.html#security).
 * **[Feature]** Include garden debug tooling alongside garden
 * **[Feature Improvement]** Add support for "windows" stack
 * **[Bug Fix]** Fix accumulating TCP Router HAProxy <defunct> instances


### PR DESCRIPTION
At the suggestion of the release engineering team, make clear what to do if installing this point release causes the problem described with Apps Manager.