### PR TITLE
Add breaking change notice for PAS 2.3/IST/PASW/PASW 2012R2

### DIFF
--- a/segment-rn.html.md.erb
+++ b/segment-rn.html.md.erb
@@ -9,6 +9,8 @@ owner: Release Engineering
 
 ## <a id='releases'></a> Releases
 
+**NOTE: BREAKING CHANGE** You must upgrade to PAS 2.3.5 or greater prior to installing IST 2.3.5 or higher
+
 ### <a id='2.3.8'></a>2.3.8
 
 * **[Security Fix]** Bump BPM to v1.0.3 for RunC CVE

--- a/segment-rn.html.md.erb
+++ b/segment-rn.html.md.erb
@@ -9,7 +9,7 @@ owner: Release Engineering
 
 ## <a id='releases'></a> Releases
 
-**NOTE: BREAKING CHANGE** You must upgrade to PAS 2.3.5 or greater prior to installing IST 2.3.5 or higher
+<p class='note breaking'><strong>Breaking Change</strong>: You must upgrade to PAS 2.3.5 or greater prior to installing IST 2.3.5 or higher.</p>
 
 ### <a id='2.3.8'></a>2.3.8
 

--- a/windows-2012r2-rn.html.md.erb
+++ b/windows-2012r2-rn.html.md.erb
@@ -8,7 +8,7 @@ Operators can install Pivotal Application Service (PAS) for Windows 2012R2 on vS
 
 ## <a id='releases'></a> Releases
 
-**NOTE: BREAKING CHANGE** You must upgrade to PAS 2.3.5 or greater prior to installing PAS for Windows 2012R2 2.3.4 or higher
+<p class='note breaking'><strong>Breaking Change</strong>: You must upgrade to PAS 2.3.5 or greater prior to installing PAS for Windows 2012R2 2.3.4 or higher.</p>
 
 ### <a id='2.3.6'></a>2.3.6
 

--- a/windows-2012r2-rn.html.md.erb
+++ b/windows-2012r2-rn.html.md.erb
@@ -8,6 +8,8 @@ Operators can install Pivotal Application Service (PAS) for Windows 2012R2 on vS
 
 ## <a id='releases'></a> Releases
 
+**NOTE: BREAKING CHANGE** You must upgrade to PAS 2.3.5 or greater prior to installing PAS for Windows 2012R2 2.3.4 or higher
+
 ### <a id='2.3.6'></a>2.3.6
 
 * **[Bug Fix]** Fix app push failures caused by inability to interpolate Credhub references by configuring `containers.trusted_ca_certificates` on `rep_windows` job

--- a/windows-rn.html.md.erb
+++ b/windows-rn.html.md.erb
@@ -12,6 +12,8 @@ use the PAS for Windows v2.3 tile, you must install Ops Manager v2.3 or later an
 
 ## <a id='releases'></a> Releases
 
+**NOTE: BREAKING CHANGE** You must upgrade to PAS 2.3.5 or greater prior to installing PAS for Windows 2.3.5 or higher
+
 ### <a id='2.3.7'></a>2.3.7
 
 * **[Feature]** Operators can provide trusted certs in OpsMgr for .NET apps to use automatically

--- a/windows-rn.html.md.erb
+++ b/windows-rn.html.md.erb
@@ -12,7 +12,7 @@ use the PAS for Windows v2.3 tile, you must install Ops Manager v2.3 or later an
 
 ## <a id='releases'></a> Releases
 
-**NOTE: BREAKING CHANGE** You must upgrade to PAS 2.3.5 or greater prior to installing PAS for Windows 2.3.5 or higher
+<p class='note breaking'><strong>Breaking Change</strong>: You must upgrade to PAS 2.3.5 or greater prior to installing PAS for Windows 2.3.5 or higher.</p>
 
 ### <a id='2.3.7'></a>2.3.7
 


### PR DESCRIPTION
Diego was bumped to 2.20.0 which caused a breaking change between
versions of PAS, IST, PASW, and PASW 2012R2

See [#164482322](https://www.pivotaltracker.com/story/show/164482322) for more details