### PR TITLE
slow container deletion was fixed in 2.3.1

### DIFF
--- a/runtime-rn.html.md.erb
+++ b/runtime-rn.html.md.erb
@@ -1350,13 +1350,15 @@ If you want to configure a list of ports, do the following:
 
 ### <a id="containers-live"></a>Containers Live Briefly after Apps are Deleted or Downsized
 
-When you delete or scale down an app, the container instance may continue running for a couple of minutes after `cf apps` and other CLI commands indicate that the instance no longer exists. 
+In v2.3.0, when you delete or scale down an app, the container instance may continue running for a couple of minutes after `cf apps` and other CLI commands indicate that the instance no longer exists. 
 
 This may cause the following:
 
 * After deletion, the container may briefly continue to appear in the IaaS dashboard.
 * Resource usage may go down to reflect container deletion only after a brief delay.
 * Acceptance tests that check for immediate container deletion may fail.
+
+This issue has been fixed in the v2.3.1 patch release.
 
 ### <a id="loggregator-scaling"></a> Loggregator Component Horizontal Scaling Thresholds
 


### PR DESCRIPTION
I just noticed that [this issue](https://docs.pivotal.io/pivotalcf/2-3/pcf-release-notes/runtime-rn.html#containers-live) is still listed in the 2.3 release notes, even though it got fixed in 2.3.1 (see "**[Bug Fix]** Fixes slow app instance shutdown when using NSX-T for container networking" in 2.3.1 release notes). I added a note mentioning that it only applies to 2.3.0 has been fixed as of 2.3.1.