### PR TITLE
Clarify description of CAPI/Spring Boot actuator bug fix [2.5, 2.4]

### DIFF
--- a/runtime-rn.html.md.erb
+++ b/runtime-rn.html.md.erb
@@ -201,7 +201,7 @@ Read more about the [certified provider program](https://www.cloudfoundry.org/pr
 * **[Bug Fix]** Fix bug where app changes pushed with --no-start does not take effect when the app was started via Apps Manager
 * **[Bug Fix]** Fix alignment of search results in Apps Manager
 * **[Bug Fix]** Fix failed access checks on mount for NFS volume service with some Windows NFS servers
-* **[Bug Fix]** Fix issue that can cause the Spring Boot actuator integration with Apps Manager to stop working after a rolling deployment
+* **[Bug Fix]** Fix issue that can cause the Spring Boot actuator integration with Apps Manager to stop working for apps pushed using the experimental [rolling app deployment](https://docs.cloudfoundry.org/devguide/deploy-apps/rolling-deploy.html) feature
 * **[Bug Fix]** Fix feature: "Operator can specify headers to be stripped from the response by the router"
 * **[Bug Fix]** Fix diego rep to always clean up temporary download cache directory
 * Bump ubuntu-xenial stemcell to version `250.25`


### PR DESCRIPTION
The current description for this bug fix caused some confusion around the scope of the original bug.

This bug only affected apps that were pushed using the experimental [Rolling App Deployments](https://docs.cloudfoundry.org/devguide/deploy-apps/rolling-deploy.html) feature via `cf v3-zdt-push` or `cf v3-zdt-restart`.

This updated description also applies to PAS 2.4, here:
https://github.com/pivotal-cf/pcf-release-notes/blob/eb46ba2011563d11aee2d7f12edc8c7222c5f198/runtime-rn.html.md.erb#L199