### PR TITLE
Autoscaler API v1 deprecation breaking change

### DIFF
--- a/breaking-changes.html.md.erb
+++ b/breaking-changes.html.md.erb
@@ -60,6 +60,10 @@ cfnetworking: cni up failed: add network list failed: initialize net out: creati
 
 This is a symptom of a failed Diego healthcheck, which can cause the Diego cell to become unhealthy. If you encounter this error, see the following Pivotal Knowledge Base article to understand and resolve the issue: [Diego Cell Garden healthcheck fails and becomes unhealthy](https://community.pivotal.io/s/article/diego-cell-garden-healthcheck-fails-and-becomes-unhealthy).  
 
+### <a id='App Autoscaler v1 API'></a> App Autoscaler v1 API endpoints are deprecated
+
+The App Autoscaler v1 API is deprecated. If you are using any v1 API functionality, you will need to update to the v2 API.
+
 ## <a id='opsman'></a> PCF Operations Manager (Ops Manager)
 
 ###<a id='xenial'></a> Updates for Xenial Stemcell Support

--- a/breaking-changes.html.md.erb
+++ b/breaking-changes.html.md.erb
@@ -60,9 +60,9 @@ cfnetworking: cni up failed: add network list failed: initialize net out: creati
 
 This is a symptom of a failed Diego healthcheck, which can cause the Diego cell to become unhealthy. If you encounter this error, see the following Pivotal Knowledge Base article to understand and resolve the issue: [Diego Cell Garden healthcheck fails and becomes unhealthy](https://community.pivotal.io/s/article/diego-cell-garden-healthcheck-fails-and-becomes-unhealthy).  
 
-### <a id='App Autoscaler v1 API'></a> App Autoscaler v1 API endpoints are deprecated
+### <a id="autoscaler-api"></a> App Autoscaler v1 API Endpoints are Unsupported
 
-The App Autoscaler v1 API is deprecated. If you are using any v1 API functionality, you will need to update to the v2 API.
+The App Autoscaler v1 API is no longer supported. If you are using any v1 API functionality, you must update to the v2 API.
 
 ## <a id='opsman'></a> PCF Operations Manager (Ops Manager)
 


### PR DESCRIPTION
Some customers were caught off-guard with the switch to the v2 API for Autoscaler in the 2.3 upgrade. https://www.pivotaltracker.com/story/show/164834806