### PR TITLE
Added Visual C++ Redistributable Note

### DIFF
--- a/windows-rn.html.md.erb
+++ b/windows-rn.html.md.erb
@@ -160,6 +160,9 @@ In PAS for Windows v2.7, the `windows2016` stack is removed. Before you upgrade 
 You can migrate your apps from `windows2016` to `windows` using Stack Auditor, a Cloud Foundry CLI plugin.
 For more information, see [Using the Stack Auditor Plugin](https://docs.pivotal.io/pivotalcf/adminguide/stack-auditor.html).
 
+### <a id='vcr-libs'></a> Pre-installed Visual C++ Redistributables
+
+Microsoft Visual C++ Redistributable for Visual Studio 2010, 2015, 2017 and 2019 have been pre-installed in PAS for Windows 2.7 and backported to PAS for Windows 2.2.
 
 ## <a id='adv-features'></a> New Advanced Features
 


### PR DESCRIPTION
The .NET Dev X team pre-installed the Visual C++ Redistributables to the  in  2.7, and they will be back ported to 2.2