### PR TITLE
Fix known issue about Apps Manager IE11 compatibility

### DIFF
--- a/runtime-rn.html.md.erb
+++ b/runtime-rn.html.md.erb
@@ -771,11 +771,11 @@ If you are on a version earlier than v2.6.1, you must upgrade to address this is
 For more information, see [Enabling TLS from the Gorouter to application instances results in bad routes in PAS 2.3+](https://community.pivotal.io/s/article/enabling-tls-from-the-gorouter-to-application-instances-results-in-bad-routes).
 
 
-### <a id="apps-manager-ie"></a> Apps Manager Shows Blank Page in Internet Explorer
+### <a id="apps-manager-ie"></a> Apps Manager Spring Boot Integration Fails in Internet Explorer
 
-In PAS v2.6.3, Apps Manager includes a change that is not compatible with the Internet Explorer 11 browser. The change results in a blank page being shown when attempting to use Apps Manager.
+In PAS v2.6.3, Apps Manager includes a change in communication with Spring Boot Actuator endpoints that is not compatible with the Internet Explorer 11 browser. The change results in Spring Boot information not appearing on the app page.
 
-This issue is fixed in PAS 2.6.3 and later, and does not affect other browsers.
+This issue is fixed in PAS v2.6.4 and later, and does not affect other browsers.
 
 
 ### <a id="apps-manager-square-logo"></a> Apps Manager Unable to Show Custom Branding Square Logo


### PR DESCRIPTION
It turns out the blank page issue was never actually applicable to PAS 2.6, only a 2.7 release candidate. 2.6.3 had the same issue as other minor versions in that release train with Spring Boot integration failing in IE11, though.