### PR TITLE
Update Custom Logo known issue

### DIFF
--- a/runtime-rn.html.md.erb
+++ b/runtime-rn.html.md.erb
@@ -781,9 +781,7 @@ This issue is fixed in PAS v2.6.4 and later and does not affect other browsers.
 
 In PAS v2.6.0 to v2.6.4, Apps Manager does not show a custom logo in its header. It instead shows the Pivotal Web Services logo. 
 
-In PAS v2.6.5 the correct PCF default logo is displayed and custom logos may be uploaded, however the uploaded logo must be the right size, otherwise it will cause layout problems.
-
-These issues are fixed in PAS v2.6.6 and later.
+In PAS v2.6.5 and v2.6.6, the correct PCF default logo is displayed and custom logos may be uploaded, however the uploaded logo must be the right size, otherwise it will cause layout problems.
 
 ### <a id="apps-manager-spring-mappings-context"></a> Apps Manager Does Not Show Spring Mappings Outside of the Application Context
 


### PR DESCRIPTION
The fix to correctly size a custom logo did not make it into v2.6.6. Updating the known issues to reflect actual state of 2.6.6