### PR TITLE
Remove release line for PAS 2.7.7

### DIFF
--- a/runtime-rn.html.md.erb
+++ b/runtime-rn.html.md.erb
@@ -118,7 +118,6 @@ Read more about the [certified provider program](https://www.cloudfoundry.org/pr
 * **[Bug Fix]** Fix bug that prevented additional resources from populating after user permissions load in Apps Manager
 * **[Bug Fix]** Fix bug preventing multiple service instances without binding names from being bound to apps in Apps Manager
 * **[Bug Fix]** Exclude user provided service instances from org level service instance hours on Usage Report in Apps Manager
-* **[Bug Fix]** Allow users with`usage_service.audit` scope to view Usage Report in Apps Manager
 * **[Bug Fix]** Account for malformed git properties in Spring and Steeltoe apps to keep Apps Manager from crashing on render
 * **[Bug Fix]** Fix bug where 'Invalid Date' was shown in Apps Manager trace tab when using Spring v2.0
 * **[Bug Fix]** Prevent Apps Manager's revisions tab from crashing out when a deployment is in progress


### PR DESCRIPTION
We discovered that there was an aspect of the fix that doesn't work, so we're removing the following release line and going to re-release the fix in a future version:
* **[Bug Fix]** Allow users with`usage_service.audit` scope to view Usage Report in Apps Manager