### PR TITLE
Remove release line from PAS 2.6.13

### DIFF
--- a/runtime-rn.html.md.erb
+++ b/runtime-rn.html.md.erb
@@ -122,7 +122,6 @@ Read more about the [certified provider program](https://www.cloudfoundry.org/pr
 * **[Bug Fix]** Prevents users from downloading the **Accounting and Usage Service** reports through Apps Manager when fields are undefined or null
 * **[Bug Fix]** Prevents multiple service instances without binding names from being bound to apps in Apps Manager
 * **[Bug Fix]** Exclude user-provided service instances from org-level service instance hours on **Usage Report** in Apps Manager
-* **[Bug Fix]** Allow users with`usage_service.audit` scope to view **Usage Report** in Apps Manager
 * **[Bug Fix]** Account for malformed Git properties in Spring and Steeltoe apps to keep Apps Manager from crashing on render
 * **[Bug Fix]** `Invalid Date` is not shown in Apps Manager trace tab when using Spring v2.0
 * **[Bug Fix]** Move tooltip in the Apps Manager bind services flyout to make text fully visible


### PR DESCRIPTION
We discovered that there was an aspect of the fix that doesn't work, so we're removing the following release line and going to re-release the fix in a future version:
* **[Bug Fix]** Allow users with`usage_service.audit` scope to view Usage Report in Apps Manager