### PR TITLE
Remove release line for PAS 2.5.18

### DIFF
--- a/runtime-rn.html.md.erb
+++ b/runtime-rn.html.md.erb
@@ -112,7 +112,6 @@ Read more about the [certified provider program](https://www.cloudfoundry.org/pr
 * **[Bug Fix]** CredHub - Upgrade to Luna Client 7.4 to be compatible with FIPS compliant HSMs
 * **[Bug Fix]** Fix bug that prevented users from downloading the Accounting and Usage Service reports through Apps Manager when fields are undefined or null
 * **[Bug Fix]** Exclude user-provided service instances from org-level service instance hours on **Usage Report** in Apps Manager
-* **[Bug Fix]** Allow users with `usage_service.audit` scope to view **Usage Report** in Apps Manager
 * **[Bug Fix]** Account for malformed Git properties in Spring and Steeltoe apps to keep Apps Manager from crashing on render
 * **[Bug Fix]** 'Invalid Date' does not show in Apps Manager trace tab when using Spring v2.0
 * **[Bug Fix]** Fix error when using `after_guid` query parameter with the `v2/app_usage_events` endpoint after all AppUsageEvents have been pruned


### PR DESCRIPTION
We discovered that there was an aspect of the fix that doesn't work, so we're removing the following release line:
* **[Bug Fix]** Allow users with`usage_service.audit` scope to view Usage Report in Apps Manager
Because 2.5 is now out of support, this bug will not be fixed for PAS 2.5.x