### PR TITLE
Updating the status for 2.8.4 as Withdrawn

### DIFF
--- a/opsmanager-rn.html.md.erb
+++ b/opsmanager-rn.html.md.erb
@@ -13,7 +13,9 @@ Read more about the [certified provider program](https://www.cloudfoundry.org/pr
 
 ## <a id='releases'></a> Releases
 
-### <a id="2-8-4"></a> 2.8.4
+### <a id="2-8-4 - Withdrawn"></a> 2.8.4 - Withdrawn
+
+**This release has been removed from Pivotal Network** because it shipped with an unintentional breaking change in BOSH DNS which causes PAS Windows deployments to fail.
 
 * **[Feature]** Adds **VM-HOST Affinity Rule** drop-down to **Availability Zones** pane. This drop-down is available if you have availability zones (AZs) on vSphere. In the drop-down, you can select either MUST or SHOULD to add a Distributed Resource Scheduler (DRS) rule for the AZ.   
 


### PR DESCRIPTION
Ops Manager team got to know about a breaking change in BOSH DNS version which was shipped with Ops Manager 2.8.4 last week. This causes failures in the integration of PAS Windows.
We have made the 2.8.4 release private (Admins only) on PivNet. We have also sent an alert to those who downloaded that release. 

We wanted to update the 2.8.4 release notes to clarify that the release has been pulled/withdrawn with a note: “This release has been removed from Pivotal Network because it shipped with an unintentional breaking change in BOSH-DNS which causes PAS Windows deployments to fail.”