### PR TITLE
Update Apps Manager Metrics Link known issue

### DIFF
--- a/runtime-rn.html.md.erb
+++ b/runtime-rn.html.md.erb
@@ -1599,10 +1599,10 @@ displays correctly.
 
 <%= partial "/pcf/app-service-kis/cf_cli_errors_disable_firehose" %>
 
-### <a id="apps-manager-pcf-metrics-link"></a> Link to PCF Metrics in Apps Manager Is Missing or Broken
+### <a id="apps-manager-app-metrics-link"></a> App Metrics 2.0.0 is incompatible with Apps Manager integration
 
-This issue affects PAS v2.7.10 and later.
+This issue affects App Metrics 2.0.0.
 
-If the PCF Metrics tile is installed on a foundation,
-then a link to the PCF Metrics dashboard usually appears on the app Overview tab in Apps Manager.
-In PAS v2.7.10 and later, this link either does not appear or is broken.
+If the App Metrics tile is installed on a foundation,
+then a link to the Metrics dashboard usually appears on the app Overview tab in Apps Manager.
+For App Metrics 2.0.0, this link either does not appear or is broken.


### PR DESCRIPTION
[#172343418](https://www.pivotaltracker.com/story/show/172343418)

We found that this is actually an issue with the App Metrics 2.0.0 tile; the tile does not implement an endpoint that the Apps Manager integration relies on. App Metrics 2.0.0 should be the only version affected, the endpoint will be restored in an upcoming patch release of App Metrics.