### PR TITLE
Update Apps Manager Metrics Link known issue

### DIFF
--- a/runtime-rn.html.md.erb
+++ b/runtime-rn.html.md.erb
@@ -2014,11 +2014,10 @@ The normal contents of the Overview tab are not displayed.
 This does not indicate a problem with the app, and information on the other tabs
 displays correctly.
 
-### <a id="apps-manager-pcf-metrics-link"></a> Link to PCF Metrics in Apps Manager Is Missing or Broken
+### <a id="apps-manager-app-metrics-link"></a> App Metrics 2.0.0 is incompatible with Apps Manager integration
 
-This issue affects PAS v2.6.16 and later.
-Because PAS v2.6 has reached the end of general support, the issue will not be fixed in PAS v2.6.
+This issue affects App Metrics 2.0.0.
 
-If the PCF Metrics tile is installed on a foundation,
-then a link to the PCF Metrics dashboard usually appears on the app Overview tab in Apps Manager.
-In PAS v2.6.16 and later, this link either does not appear or is broken.
+If the App Metrics tile is installed on a foundation,
+then a link to the Metrics dashboard usually appears on the app Overview tab in Apps Manager.
+For App Metrics 2.0.0, this link either does not appear or is broken.


### PR DESCRIPTION
[#172343418](https://www.pivotaltracker.com/story/show/172343418)

We found that this is actually an issue with the App Metrics 2.0.0 tile; the tile does not implement an endpoint that the Apps Manager integration relies on. App Metrics 2.0.0 should be the only version affected, the endpoint will be restored in an upcoming patch release of App Metrics.