### PR TITLE
Call out that Optional Dependencies is a new feature

### DIFF
--- a/opsmanager-rn.html.md.erb
+++ b/opsmanager-rn.html.md.erb
@@ -224,7 +224,11 @@ TLS is now always enabled for the internal blobstore. You can no longer toggle T
 
 <%= vars.recommended_by %> recommends that you enable TLS for the internal blobstore before you upgrade. You can do this by selecting **Enable TLS** in the **Director Config** pane. There may be errors if the blobstore CA is expired.
 
-### <a id='optional-dependencies'></a> <%= vars.ops_manager %> UI and API Show More Information about Dependencies
+### <a id='optional-dependencies'></a> <%= vars.ops_manager %> Optional Dependencies
+
+Tile dependencies can now be specified as optional by specifying `optional: true`, see tile dev [docs](https://docs.pivotal.io/tiledev/2-8/property-template-references.html#top-requires).
+
+#### UI and API Show More Information about Dependencies
 
 <%= vars.ops_manager %> v2.8 changes the way dependencies appear when you selectively deploy products. When you click **Review Pending Changes** in the <%= vars.ops_manager %> UI, each product lists its dependencies in the **Depends on** section. When you make a request to the `pending_changes` <%= vars.ops_manager %> API endpoint, the response lists each product's dependencies in the `depends_on` section.
 


### PR DESCRIPTION
It's not just a UI/API change on the selective deploy page

[#172489344] Add missing tile dev documentation for `optional` in `requires_product_versions`