### PR TITLE
clarify language for credhub instance requirement

### DIFF
--- a/highlights.html.md.erb
+++ b/highlights.html.md.erb
@@ -80,9 +80,9 @@ For more information about deploying sidecar processes with apps, see [Pushing A
 
 ### <a id='credhub-instance-count'></a> <%= vars.app_runtime_abbr %> Deployed With CredHub by Default
 
-You must use at least one CredHub VM when you deploy <%= vars.app_runtime_abbr %> v2.8. The default number of CredHub instances is increased from `0` to `2`. You can configure the number of CredHub VMs <%= vars.app_runtime_abbr %> uses in the **Resource Config** pane of the <%= vars.app_runtime_abbr %> tile.
+CredHub is now required in <%= vars.app_runtime_abbr %>. Components in <%= vars.app_runtime_abbr %> require data stored in CredHub.
 
-This update improves platform security by deploying <%= vars.app_runtime_abbr %> with CredHub by default. It also helps to avoid unexpected behaviors that occur when there are zero CredHub instances.
+You must use at least one CredHub VM when you deploy <%= vars.app_runtime_abbr %> v2.8. The default number of CredHub instances is increased from `0` to `2`. You can configure the number of CredHub VMs <%= vars.app_runtime_abbr %> uses in the **Resource Config** pane of the <%= vars.app_runtime_abbr %> tile.
 
 ### <a id='cpu-entitlement'></a> CPU Usage Metric Is Relative to CPU Entitlement for the Container
 


### PR DESCRIPTION
Customers have been asking if CredHub is really required and why
when upgrading to 2.8. We are hoping a change to the language
will reduce interrupts we receive on the topic.

Signed-off-by: Aidan Obley <aobley@vmware.com>
Co-authored-by: Aidan Obley <aobley@vmware.com>