### PR TITLE
Remove duplicated fix

### DIFF
--- a/runtime-rn.html.md.erb
+++ b/runtime-rn.html.md.erb
@@ -190,7 +190,6 @@ Read more about the [certified provider program](https://www.cloudfoundry.org/pr
 * **[Feature Improvement]** HTTP trace requests now respond with a generic error page
 * **[Bug Fix]** Safeguard against unavailable stack traces in Spring and Steeltoe threaddump actuator endpoint in Apps Manager
 * **[Bug Fix]** Update Reverse Log Proxies to fix shutdown issues in Loggregator
-* **[Bug Fix]** Add a new cache configuration to the NFS service allowing service instances to enable file attribute caching and achieve directory listing performance similar to the nfs-legacy service
 * Bump cf-smoke-tests to version `40.0.128`
 * Bump cflinuxfs3 to version `0.189.0`
 * Bump credhub to version `2.5.12`


### PR DESCRIPTION
We can see the following bug fix duplicated as a bug fix for TAS 2.7.16 and 2.7.18
* [Bug Fix] Add a new cache configuration to the NFS service allowing service instances to enable file attribute caching and achieve directory listing performance similar to the nfs-legacy service

This should be fixed with TAS 2.7.18 bundling nfs-volume v2.3.9 while TAS 2.7.17 bundles nfs-volume v2.3.6, which does not have the above bug fix, according to the differences between nfs-volume v2.3.5 and 2.3.9.
https://github.com/cloudfoundry/nfs-volume-release/compare/v2.3.5...v2.3.9