### PR TITLE
Update Ops Manager 2.8.10 release notes

### DIFF
--- a/opsmanager-rn.html.md.erb
+++ b/opsmanager-rn.html.md.erb
@@ -17,7 +17,6 @@ Read more about the [certified provider program](https://www.cloudfoundry.org/pr
 
 **Release Date:** July 1, 2020
 
-* **[Feature]:** Adds an **Enable additional System Metrics** checkbox to the Director Config screen and adds `metrics_server_enabled` and `system_metrics_runtime_enabled` accessors to `$director`. These configurations are used by Tanzu Application Service for VMs (TAS for VMs) deployments.
 * **[Bug Fix]:** NSX configuration settings are applied to jobs defined in the BOSH Director manifest, including the BOSH Director VM.
 * **[Bug Fix]:** BOSH Director can deploy on Openstack environments with multiple regions.
 * **[Bug Fix]:** The Ops Manager API `/api/v0/staged/director/properties` endpoint returns S3 and GCS blobstore credentials.


### PR DESCRIPTION
The feature about adding the ability to configure the system metrics feature was originally going to go out in 2.8.10, but was subsequently removed and will not go into 2.8 at all.